### PR TITLE
topologically ordered update cycle

### DIFF
--- a/build_npm.ts
+++ b/build_npm.ts
@@ -88,10 +88,10 @@ await build({
 	mappings: Object.fromEntries(
 		["binder", "builtin_aliases_deps", "lambda", "struct", "typedefs",].map((submodule_path) => {
 			return [
-				"https://deno.land/x/kitchensink_ts@v0.7.2/" + submodule_path + ".ts",
+				"https://deno.land/x/kitchensink_ts@v0.7.3/" + submodule_path + ".ts",
 				{
 					name: "kitchensink_ts",
-					version: "^v0.7.2",
+					version: "^v0.7.3",
 					subPath: submodule_path,
 				}
 			]

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "tsignal_ts",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"description": "a topological order respecting signals library inspired by SolidJS",
 	"author": "Omar Azmi",
 	"license": "Lulz plz don't steal yet",
@@ -21,7 +21,7 @@
 		"allowJs": true
 	},
 	"dependencies": {
-		"kitchensink_ts": "^0.7.2"
+		"kitchensink_ts": "^0.7.3"
 	},
 	"devDependencies": {
 		"typescript": "^5.0.0",

--- a/src/async_signal.ts
+++ b/src/async_signal.ts
@@ -56,7 +56,7 @@ export const AsyncStateSignal_Factory = (ctx: Context) => {
 					}
 				)
 			}
-			// the signal update is first propagated, and then the returned promise is resolved with the value we jsut set
+			// the signal update is first propagated, and then the returned promise is resolved with the value we just set
 			const value_has_changed = super.set(new_value as T)
 			if (value_has_changed) { runId(this.id) }
 			return promise_resolve(new_value as T)

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,7 +3,7 @@
 */
 
 import { DEBUG, bindMethodToSelfByName, bind_array_clear, bind_array_pop, bind_array_push, bind_map_clear, bind_map_delete, bind_map_get, bind_map_set, bind_set_add, bind_set_clear, bind_set_delete, bind_set_has } from "./deps.ts"
-import { hash_ids, symmetric_difference_of_sets } from "./funcdefs.ts"
+import { hash_ids } from "./funcdefs.ts"
 import { EffectFn, MemoFn, SimpleSignalInstance } from "./signal.ts"
 import { EqualityFn, FROM_ID, HASHED_IDS, ID, Signal, SignalClass, SignalUpdateStatus, TO_ID, UNTRACKED_ID } from "./typedefs.ts"
 
@@ -53,126 +53,177 @@ export class Context {
 			rmap_delete = bind_map_delete(rmap)
 
 		const
-			ids_to_visit_cache = new Map<HASHED_IDS, Set<ID>>(),
+			ids_to_visit_cache = new Map<HASHED_IDS, ID[]>(),
 			ids_to_visit_cache_get = bind_map_get(ids_to_visit_cache),
 			ids_to_visit_cache_set = bind_map_set(ids_to_visit_cache),
-			ids_to_visit_cache_clear = bind_map_clear(ids_to_visit_cache),
-			ids_to_visit_cache_create_new_entry = (source_ids: ID[]): Set<ID> => {
-				const
-					to_visit = new Set<ID>(),
-					to_visit_add = bind_set_add(to_visit),
-					to_visit_has = bind_set_has(to_visit)
-				const dfs_visiter = (id: ID) => {
-					if (!to_visit_has(id)) {
-						to_visit_add(id)
-						fmap_get(id)?.forEach(dfs_visiter)
-					}
+			ids_to_visit_cache_clear = bind_map_clear(ids_to_visit_cache)
+
+		/** creates a topologically ordered array of ids to visit, when propagation is initiated from `source_ids`. <br>
+		 * the function ensures that `source_ids` are always put at the very beginning of the retuned value,
+		 * as this kind of ordering is of utter importance to the {@link fireUpdateCycle | `fireUpdateCycle`} function, which uses this.
+		 * @example
+		 * ```ts
+		 * // assume our directed acyclic graph is:
+		 * // A->[B,C] ; B->[D, F] ; C->[E, F] ; D->[F, G] ; E->[F, H] ; F->[I] ; G->[I] ; H->[I] ; I->[J] ;
+		 * console.log(ids_to_visit_cache_create_new_entry([A])) // [A, C, E, H, B, D, F, G, I, J]
+		 * console.log(ids_to_visit_cache_create_new_entry([B, E])) // [E, B, D, F, G, H, I, J]
+		 * // notice that B and E were placed first, even though enforcing it was not necessary for the array to be still considered as topologically ordered.
+		 * ```
+		*/
+		const ids_to_visit_cache_create_new_entry = (source_ids: ID[]): ID[] => {
+			const
+				to_visit = new Set<ID>(),
+				to_visit_add = bind_set_add(to_visit),
+				to_visit_has = bind_set_has(to_visit)
+			const dfs_visitor = (id: ID) => {
+				if (!to_visit_has(id)) {
+					fmap_get(id)?.forEach(dfs_visitor)
+					to_visit_add(id)
 				}
-				source_ids.forEach(dfs_visiter)
-				return to_visit
-			},
-			get_ids_to_visit = (...source_ids: ID[]): Set<ID> => {
-				const hash = hash_ids(source_ids)
-				return ids_to_visit_cache_get(hash) ?? (
-					ids_to_visit_cache_set(hash, ids_to_visit_cache_create_new_entry(source_ids)) &&
-					ids_to_visit_cache_get(hash)!
-				)
 			}
+			source_ids.forEach(dfs_visitor)
+			// delete the `source_ids` from `to_visit`, as will add them later to the very beginning of the return array
+			source_ids.forEach(bind_set_delete(to_visit))
+			// currently, `to_visit` is in reverse-topological order, which is what you get with the type of DFS we're doing here.
+			// so reverse `to_visit` to get a topologically ordered set
+			return [...to_visit, ...source_ids].reverse()
+		}
+
+		/** get a topologically ordered set of ids to visit, when propagation is initiated from `source_ids`.
+		 * the result is cached for quicker followup retrievals.
+		 * see {@link ids_to_visit_cache_create_new_entry | `ids_to_visit_cache_create_new_entry`} for a better explanation.
+		*/
+		const get_ids_to_visit = (...source_ids: ID[]): ID[] => {
+			const hash = hash_ids(source_ids)
+			return ids_to_visit_cache_get(hash) ?? (
+				ids_to_visit_cache_set(hash, ids_to_visit_cache_create_new_entry(source_ids)) &&
+				ids_to_visit_cache_get(hash)!
+			)
+		}
 
 		const
+			/** contains a mapping of all signal `ID`s and their {@link Signal | signal instances} */
 			all_signals = new Map<ID, Signal<any>>(),
 			all_signals_get = bind_map_get(all_signals),
 			all_signals_set = bind_map_set(all_signals),
 			all_signals_delete = bind_map_delete(all_signals)
 
 		const
-			to_visit_this_cycle = new Set<ID>(),
-			to_visit_this_cycle_add = bind_set_add(to_visit_this_cycle),
-			to_visit_this_cycle_delete = bind_set_delete(to_visit_this_cycle),
-			to_visit_this_cycle_clear = bind_set_clear(to_visit_this_cycle),
-			updated_this_cycle = new Map<ID, SignalUpdateStatus>(),
-			updated_this_cycle_get = bind_map_get(updated_this_cycle),
-			updated_this_cycle_set = bind_map_set(updated_this_cycle),
-			updated_this_cycle_clear = bind_map_clear(updated_this_cycle),
+			/** this `Set` of `ID`s is essentially a dynamic book-keeper for which signal `ID`s have had their dependency-signals declare an update,
+			 * and as a result, these set of `ID`s are now awaiting in queue to be executed themselves, in the follow-up update loop.
+			 * this technique works correctly, particularly because {@link fireUpdateCycle |update cycle's} loop is topologically ordered.
+			 * and so, we are guaranteed to have encountered all of a certain `ID`'s dependency-signals, before we test for its existence **here** via deletion.
+			*/
+			next_to_visit_this_cycle = new Set<ID>(),
+			next_to_visit_this_cycle_add = bind_set_add(next_to_visit_this_cycle),
+			next_to_visit_this_cycle_delete = bind_set_delete(next_to_visit_this_cycle),
+			next_to_visit_this_cycle_clear = bind_set_clear(next_to_visit_this_cycle)
+
+		const
+			// TODO: consider whether or not aborted signals should poison only their immediate observers, or have it propagate deeply into all consequent observers.
+			/** this is very similar to {@link next_to_visit_this_cycle}, except, it book-keeps which signals have been declared aborted.
+			 * aborted signals are never run, and they poison their immediate observers to also become aborted and not run (even if they have a dependency that has been updated).
+			*/
+			not_to_visit_this_cycle = new Set<ID>(),
+			not_to_visit_this_cycle_add = bind_set_add(not_to_visit_this_cycle),
+			not_to_visit_this_cycle_has = bind_set_has(not_to_visit_this_cycle),
+			not_to_visit_this_cycle_clear = bind_set_clear(not_to_visit_this_cycle)
+
+		const
+			/** when {@link DEBUG.LOG | debug-logging} is turned on, this gives a summary of what has been updated,
+			 * and what topologically-ordered trajectory was taken for the update.
+			*/
+			status_this_cycle = /* @__PURE__ */ new Map<ID, SignalUpdateStatus>(),
+			status_this_cycle_set = /* @__PURE__ */ bind_map_set(status_this_cycle),
+			status_this_cycle_clear = /* @__PURE__ */ bind_map_clear(status_this_cycle)
+
+		const
+			/** certain signals have cleaning up to do *after* each update cycle.
+			 * those callback functions are stored here, and then called in reverse order
+			*/
 			postruns_this_cycle: ID[] = [],
 			postruns_this_cycle_push = bind_array_push(postruns_this_cycle),
-			postruns_this_cycle_clear = bind_array_pop(postruns_this_cycle),
+			postruns_this_cycle_clear = bind_array_pop(postruns_this_cycle)
+
+		const fireUpdateCycle = (...source_ids: FROM_ID[]) => {
+			// clear up all book-keeping artifacts from the any previous update cycle, and start anew.
+			next_to_visit_this_cycle_clear()
+			not_to_visit_this_cycle_clear()
+			if (DEBUG.LOG) { /* @__PURE__ */ status_this_cycle_clear() }
+			source_ids.forEach(next_to_visit_this_cycle_add)
+			/** some signals make use of the information whether of not they are the source of a cycle via the optional `forced` argument of {@link Signal.run | `Signal.run`}.
+			 * so we simply take a note of how many source signals we begun with, and decrement it each time in the loop.
+			 * this works because the first few items of {@link topological_ids} is guaranteed to be the {@link source_ids},
+			 * thanks to {@link get_ids_to_visit} (which guarantees this behavior).
+			 * the `forced` parameter is of particular importance to signals that can fire on their own, such as state signal and effect signals in [`./signal.ts`](./signal.ts).
+			*/
+			let number_of_forced_ids = source_ids.length
+			const topological_ids = get_ids_to_visit(...source_ids)
+			for (const source_id of topological_ids) {
+				if (
+					next_to_visit_this_cycle_delete(source_id) &&
+					!not_to_visit_this_cycle_has(source_id)
+				) {
+					const signal_update_status = executeSignal(source_id, number_of_forced_ids-- > 0)
+					if (signal_update_status !== SignalUpdateStatus.UNCHANGED) {
+						fmap_get(source_id)?.forEach(
+							signal_update_status >= SignalUpdateStatus.UPDATED ?
+								next_to_visit_this_cycle_add :
+								not_to_visit_this_cycle_add
+						)
+					}
+					if (DEBUG.LOG) { status_this_cycle_set(source_id, signal_update_status) }
+				}
+				// if there are no remaining ids `to_visit_this_cycle`, then it is our cue to terminate early,
+				// since the remaining `source_id`s will not be part of the update.
+				if (next_to_visit_this_cycle.size <= 0) { break }
+			}
+			if (DEBUG.LOG) {
+				console.log("topological visiting ordering: ", [...status_this_cycle].map(([id, status]) => {
+					return [all_signals_get(id)!.name, status]
+				}))
+			}
+			// run all of the `postrun` cleanup methods after the end of this cycle (in reverse order of accumulation)
+			if (DEBUG.LOG) { console.log("UPDATE_POSTRUNS:\t", postruns_this_cycle) }
+			let postrun_id: ID | undefined
+			while (postrun_id = postruns_this_cycle_clear()) {
+				all_signals_get(postrun_id)?.postrun!()
+			}
+		}
+
+		const executeSignal = (id: ID, force?: true | any): SignalUpdateStatus => {
+			const
+				forced = force === true,
+				this_signal = all_signals_get(id),
+				this_signal_update_status = this_signal?.run(forced) ?? SignalUpdateStatus.UNCHANGED
+			if (
+				this_signal_update_status >= SignalUpdateStatus.UPDATED &&
+				this_signal!.postrun
+			) { postruns_this_cycle_push(id) }
+			return this_signal_update_status
+		}
+
+		const
+			/** this is used by the {@link batch | batching-functions} to collect source `ID`s, and then dispatch all at once. */
 			batched_ids: FROM_ID[] = [],
 			batched_ids_push = bind_array_push(batched_ids),
-			batched_ids_clear = bind_array_clear(batched_ids),
-			fireUpdateCycle = (...source_ids: FROM_ID[]) => {
-				to_visit_this_cycle_clear()
-				updated_this_cycle_clear()
-				// clone the ids to visit into the "visit cycle for this update"
-				get_ids_to_visit(...source_ids).forEach(to_visit_this_cycle_add)
-				// fire the signal and propagate its reactivity.
-				// the souce signals are `force`d in order to skip any unresolved dependency check.
-				// this is needed because although state signals do not have dependencies, effect signals may have one.
-				// but effect signals are themselves designed to be fired/ran as standalone signals
-				for (const source_id of source_ids) {
-					propagateSignalUpdate(source_id, true)
-				}
-				// run all of the `postrun` cleanup methods after the end of this cycle (in reverse order of accumulation)
-				if (DEBUG.LOG) { console.log("UPDATE_POSTRUNS:\t", postruns_this_cycle) }
-				let postrun_id: ID | undefined
-				while (postrun_id = postruns_this_cycle_clear()) {
-					all_signals_get(postrun_id)?.postrun!()
-				}
-			},
-			startBatching = () => (++batch_nestedness),
-			endBatching = () => {
-				if (--batch_nestedness <= 0) {
-					batch_nestedness = 0
-					fireUpdateCycle(...batched_ids_clear())
-				}
-			},
-			scopedBatching = <T extends any = void, ARGS extends any[] = []>(
-				fn: (...args: ARGS) => T,
-				...args: ARGS
-			): T => {
-				startBatching()
-				const return_value = fn(...args)
-				endBatching()
-				return return_value
-			}
+			batched_ids_clear = bind_array_clear(batched_ids)
 
-		const propagateSignalUpdate = (id: ID, force?: true | any) => {
-			if (to_visit_this_cycle_delete(id)) {
-				const
-					forced = force === true,
-					this_signal = all_signals_get(id)
-				if (DEBUG.LOG) { console.log("UPDATE_CYCLE\t", "visiting   :\t", this_signal?.name) }
-				// first make sure that all of this signal's dependencies are up to date (should they be among the set of ids to visit this update cycle)
-				// `any_updated_dependency` is always initially `false`. however, if the signal id was `force`d, then it would be `true`, and skip dependency checking and updating.
-				// you must use `force === true` for `StateSignal`s (because they are dependency free), or for a independently fired `EffectSignal`
-				let any_updated_dependency: SignalUpdateStatus = forced ? SignalUpdateStatus.UPDATED : SignalUpdateStatus.UNCHANGED
-				if (any_updated_dependency <= SignalUpdateStatus.UNCHANGED) {
-					for (const dependency_id of rmap_get(id) ?? []) {
-						propagateSignalUpdate(dependency_id)
-						any_updated_dependency |= updated_this_cycle_get(dependency_id) ?? SignalUpdateStatus.UNCHANGED
-					}
-				}
-				// now, depending on two AND criterias:
-				// 1) at least one dependency has updated (or must be free of dependencies via `force === true`)
-				// 2) AND, this signal's value has changed after the update computation (ie `run()` method)
-				// if both criterias are met, then this signal should propagate forward towards its observers
-				let this_signal_update_status: SignalUpdateStatus = any_updated_dependency
-				if (this_signal_update_status >= SignalUpdateStatus.UPDATED) {
-					this_signal_update_status = this_signal?.run(forced) ?? SignalUpdateStatus.UNCHANGED
-					/* I think we should ignore batching aborted source-signals here. instead, we should let the source itself handle how it wishes to be batched, or when it wishes to run
-					if (this_signal_update_status <= SignalUpdateStatus.ABORTED) {
-						// we only batch source ids which result in an ABORTED signal, rather than the collateral resulting ABORTED signals as a consequence
-						batched_ids_push(id)
-					}
-					*/
-				}
-				updated_this_cycle_set(id, this_signal_update_status)
-				if (DEBUG.LOG) { console.log("UPDATE_CYCLE\t", this_signal_update_status > 0 ? "propagating:\t" : this_signal_update_status < 0 ? "delaying    \t" : "blocking   :\t", this_signal?.name) }
-				if (this_signal_update_status >= SignalUpdateStatus.UPDATED) {
-					if (this_signal!.postrun) { postruns_this_cycle_push(id) }
-					fmap_get(id)?.forEach(propagateSignalUpdate)
-				}
+		const startBatching = () => (++batch_nestedness)
+		const endBatching = () => {
+			if (--batch_nestedness <= 0) {
+				batch_nestedness = 0
+				fireUpdateCycle(...batched_ids_clear())
 			}
+		}
+		const scopedBatching = <T extends any = void, ARGS extends any[] = []>(
+			fn: (...args: ARGS) => T,
+			...args: ARGS
+		): T => {
+			startBatching()
+			const return_value = fn(...args)
+			endBatching()
+			return return_value
 		}
 
 		this.addEdge = (src_id: FROM_ID, dst_id: TO_ID): boolean => {

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -11,11 +11,11 @@ export {
 	bind_set_clear,
 	bind_set_delete,
 	bind_set_has
-} from "https://deno.land/x/kitchensink_ts@v0.7.2/binder.ts"
-export { array_isArray, noop, object_assign, object_keys, object_values, promise_forever, promise_reject, promise_resolve } from "https://deno.land/x/kitchensink_ts@v0.7.2/builtin_aliases_deps.ts"
-export { THROTTLE_REJECT, throttle, throttleAndTrail } from "https://deno.land/x/kitchensink_ts@v0.7.2/lambda.ts"
-export { prototypeOfClass } from "https://deno.land/x/kitchensink_ts@v0.7.2/struct.ts"
-export type { CallableFunctionsOf, ConstructorOf, MethodsOf, StaticImplements } from "https://deno.land/x/kitchensink_ts@v0.7.2/typedefs.ts"
+} from "https://deno.land/x/kitchensink_ts@v0.7.3/binder.ts"
+export { array_isArray, noop, object_assign, object_keys, object_values, promise_forever, promise_reject, promise_resolve } from "https://deno.land/x/kitchensink_ts@v0.7.3/builtin_aliases_deps.ts"
+export { THROTTLE_REJECT, throttle, throttleAndTrail } from "https://deno.land/x/kitchensink_ts@v0.7.3/lambda.ts"
+export { prototypeOfClass } from "https://deno.land/x/kitchensink_ts@v0.7.3/struct.ts"
+export type { CallableFunctionsOf, ConstructorOf, MethodsOf, StaticImplements } from "https://deno.land/x/kitchensink_ts@v0.7.3/typedefs.ts"
 
 export const enum DEBUG {
 	LOG = 0,

--- a/src/funcdefs.ts
+++ b/src/funcdefs.ts
@@ -10,12 +10,12 @@ export const falsey_equality = (<T>(v1: T, v2: T) => false) satisfies EqualityFn
 export const parseEquality = <T>(equals: EqualityCheck<T>) => (equals === false ? falsey_equality : (equals ?? default_equality)) satisfies EqualityFn<any>
 
 /** transforms a regular equality check function ({@link SimpleSignalConfig.equals}) into a one that throttles when called too frequently. <br>
- * this means that a singal composed of this as its `equals` function will limit propagating itself further, until at least `delta_time_ms`
+ * this means that a signal composed of this as its `equals` function will limit propagating itself further, until at least `delta_time_ms`
  * amount of time has passed since the last time it was potentially propagated.
  * 
  * @param delta_time_ms the time interval in milliseconds for throttling
  * @param base_equals use an optional customized equality checking function. otherwise the default `prev_value === new_value` comparison will be used
- * @returns a throttled version of the equality checking function which would prematurely return a `true` if called too frequently (ie within `delta_time_ms` interval since the last actual equality cheking)
+ * @returns a throttled version of the equality checking function which would prematurely return a `true` if called too frequently (ie within `delta_time_ms` interval since the last actual equality checking)
  * 
  * @example
  * ```ts

--- a/src/record_signal.ts
+++ b/src/record_signal.ts
@@ -14,10 +14,10 @@ import { Accessor, EqualityCheck, EqualityFn, ID, SignalUpdateStatus, TO_ID, UNT
 
 
 export interface RecordSignalConfig<K extends PropertyKey, V> {
-	/** give a name to the signal for debuging purposes */
+	/** give a name to the signal for debugging purposes */
 	name?: string
 
-	/** when a signal's value is updated (either through a {@link Setter}, or a change in the value of a dependancy signal in the case of a memo),
+	/** when a signal's value is updated (either through a {@link Setter}, or a change in the value of a dependency signal in the case of a memo),
 	 * then the dependants/observers of THIS signal will only be notified if the equality check function evaluates to a `false`. <br>
 	 * see {@link EqualityCheck} to see its function signature and default behavior when left `undefined`
 	*/

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -11,10 +11,10 @@ import { Accessor, EqualityCheck, EqualityFn, ID, Setter, SignalClass, SignalUpd
 //	signal to defer its first run, yet you also want that signal to react to any of its dependencies, before this signal ever gets run
 
 export interface SimpleSignalConfig<T> {
-	/** give a name to the signal for debuging purposes */
+	/** give a name to the signal for debugging purposes */
 	name?: string
 
-	/** when a signal's value is updated (either through a {@link Setter}, or a change in the value of a dependancy signal in the case of a memo),
+	/** when a signal's value is updated (either through a {@link Setter}, or a change in the value of a dependency signal in the case of a memo),
 	 * then the dependants/observers of THIS signal will only be notified if the equality check function evaluates to a `false`. <br>
 	 * see {@link EqualityCheck} to see its function signature and default behavior when left `undefined`
 	*/

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -136,15 +136,15 @@ export interface Signal<T> {
 	run(forced?: boolean): SignalUpdateStatus
 
 	/** specify actions that need to be taken __after__ an update cycle has fully propagated till the end. <br>
-	 * the order in which `postrun`s will be execuded will be in the reverse order in which they were first encountered (i.e: last in, last out).
-	 * meaning that if all three singals `A`, `B`, and `C`, had `postrun` methods on them, and the order of execution was:
+	 * the order in which `postrun`s will be executed will be in the reverse order in which they were first encountered (i.e: last in, last out).
+	 * meaning that if all three signals `A`, `B`, and `C`, had `postrun` methods on them, and the order of execution was:
 	 * `A -> B -> C`, then all `postrun`s will run in the order: `[C.postrun, B.postrun, A.postrun]` (similar to a stack popping).
 	*/
 	postrun?(): void
 
 	/** a utility method defined in {@link signal!SimpleSignal}, which allows one to bind a certain method (by name) to _this_ instance of a signal,
 	 * and therefore make that method freeable/seperable from _this_ signal. <br>
-	 * this method is used by all signal classes's static {@link SignalClass.create} mehod, which is supposed to construct a signal in
+	 * this method is used by all signal classes's static {@link SignalClass.create} method, which is supposed to construct a signal in
 	 * a fashion similar to SolidJS, and return an array containing important control functions of the created signal.
 	 * most, if not all, of these control function are generally plain old signal methods that have been bounded to the created signal instance.
 	*/
@@ -161,7 +161,7 @@ export interface SignalClass {
  * these numbers convey the following instructions to the context's topological update cycle {@link context!Context.propagateSignalUpdate}:
  * - ` 1`: this signal's value has been updated, and therefore its observers should be updated too.
  * - ` 0`: this signal's value has not changed, and therefore its observers should be _not_ be updated.
- *   do note that an observer signal will still run if some _other_ of its dependency signal did updat this cycle (i.e. had a status value of `1`)
+ *   do note that an observer signal will still run if some _other_ of its dependency signal did update this cycle (i.e. had a status value of `1`)
  * - `-1`: this signal has been aborted, and therefore its observers must abort execution as well.
  *   the observers will abort _even_ if they had a dependency that _did_ update (had a status value of `1`)
  * 

--- a/test/async_signal.test.ts
+++ b/test/async_signal.test.ts
@@ -91,7 +91,7 @@ Deno.test("test asynchronous behavior when old promise is replaced", async () =>
 	eval_after(100, () => assert(A() === 5 && (H() === 5 + 135) && (H() === A() + G()))) // promise_a1 remains unresolved, hence the initial values
 	eval_after(150, () => {
 		setPromiseA(promise_a2).then((v) => {
-			console.log("promise_a2 overrided promise_a1 (which then was unresolved), and promise_a2 is now fulfilled")
+			console.log("promise_a2 overridden promise_a1 (which then was unresolved), and promise_a2 is now fulfilled")
 			assert(true && v === 21)
 		})
 	})
@@ -114,7 +114,7 @@ Deno.test("test promise rejection with rejectable option", async () => {
 
 	console.log(
 		"\n\tasynchronously firing: A with three promises.",
-		"\n\t\tpromise_a1 should be overriden by promise_a2.",
+		"\n\t\tpromise_a1 should be overridden by promise_a2.",
 		"\n\t\tpromise_a2 should be rejected then caught.",
 		"\n\t\tpromise_a3 should be fulfilled"
 	)
@@ -132,11 +132,11 @@ Deno.test("test promise rejection with rejectable option", async () => {
 	eval_after(150, () => {
 		setPromiseA(promise_a2, true).then(
 			(v) => {
-				console.log("promise_a2 overrided promise_a1, and promise_a2 is now fulfilled. THIS SHOULD NOT HAPPED!")
+				console.log("promise_a2 overridden promise_a1, and promise_a2 is now fulfilled. THIS SHOULD NOT HAPPED!")
 				assert(false && v === 21)
 			},
 			(reason) => {
-				console.log("promise_a2 overrided promise_a1, and promise_a2 is now rejected.\n\tthis was logged because setPromiseA was set to be \"rejectable = true\".\n\treason for rejection: ", reason)
+				console.log("promise_a2 overridden promise_a1, and promise_a2 is now rejected.\n\tthis was logged because setPromiseA was set to be \"rejectable = true\".\n\treason for rejection: ", reason)
 				assert(true)
 			}
 		)

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -6,7 +6,7 @@ const
 	createState = ctx.addClass(StateSignal_Factory),
 	createMemo = ctx.addClass(MemoSignal_Factory)
 
-/** our signals are initally organized as follows:
+/** our signals are initially organized as follows:
  * A────┬──────────────┬──────────────┐
  *     ╭┼╮            ╭┼╮             │
  * B ──┘│└───┬────┬───┘│└────────┐    │
@@ -80,7 +80,7 @@ Deno.test("test signal dependency edge deletion and manual addition", () => {
 	setA(1)
 	console.log("deleting the edge A -> D, which should in turn stop the updating of D, I, and J")
 	ctx.delEdge(idA, idD)
-	/** our signals are initally organized as follows:
+	/** our signals are initially organized as follows:
 	 * A───────────────────┬──────────────┐
 	 *                    ╭┼╮             │
 	 * B ────────┬────┬───┘│└────────┐    │

--- a/test/record_signal.test.ts
+++ b/test/record_signal.test.ts
@@ -57,7 +57,7 @@ const
 		}
 		return [legal_rect_keys, legal_rect_values]
 	}, { name: "AllLegalRects", value: [] }),
-	[, getBoundinBox] = createMemo<BoundingBox>((id) => {
+	[, getBoundingBox] = createMemo<BoundingBox>((id) => {
 		const [legal_rects, ...changed_keys] = getChangedLegalRects(id)
 		const bb: BoundingBox = {
 			minY: Math.min(2000, ...changed_keys.map((i) => legal_rects[i].top)),

--- a/test/simple_signal.test.ts
+++ b/test/simple_signal.test.ts
@@ -30,7 +30,7 @@ Deno.test("test logging", () => {
 })
 
 Deno.test("test cached performance", () => {
-	// @ts-ignore: don't want our performace test impacted by console logging
+	// @ts-ignore: don't want our performance test impacted by console logging
 	DEBUG.LOG = 0
 	let start = performance.now()
 	for (let A_value = 0; A_value < 100_000; A_value++) {
@@ -44,9 +44,9 @@ Deno.test("test cached performance", () => {
 })
 
 Deno.test("test uncached performance", () => {
-	// @ts-ignore: don't want our performace test impacted by console logging
+	// @ts-ignore: don't want our performance test impacted by console logging
 	DEBUG.LOG = 0
-	// twice as slow as chached's performance
+	// twice as slow as cached's performance
 	const clear_dfs_cache = ctx.newId
 	let start = performance.now()
 	for (let A_value = 0; A_value < 100_000; A_value++) {


### PR DESCRIPTION
### description:
this pr fixes the previously incorrect topological ordering of the signals' execution. see issue #4 .
in addition, the new implementation is much faster than the previous one (3 times faster in cached-mode, 4 times faster in uncached-mode).

### related issues:
- #4 update cycle is not topologically ordered

### excerpt from git comments:

changes:
- `ids_to_visit_cache_create_new_entry` now generates the list of ids to visit in topological visitation order, while also maintainin that the original source ids are always at the beginning, which is an important piece of info used for a micro-optimization by `fireUpdateCycle`
- each cycle we maintain two dynamic book-keeping sets:
  - `next_to_visit_this_cycle`: which unvisited ids **must** be visited later on (since one of their dependencies have updated)
  - `not_to_visit_this_cycle`: which ids have been declared as aborted by one of their dependencies. (and therefore must never run)
- `fireUpdateCycle`: traverses through the topologically ordered set of ids, executing the signals one-by-one, updating the 2 book-keeping sets, checking of the possiblity of early termination, and then finally running all `postrun`s
- `executeSignal`: simply runs the `run` method of the retrived signal, and stores any `postrun` functions it may contain, then returns the update status of the singnal's `run` method
- add documentation to a bunch of inner functions of the `Context`

improvements:
- the cycle also runs MAD faster now, since we are no longer having to retrieve dependencies of each newly visited ids via `rmap_get` hashmap table.
- for comparison, the benchmark test 2 and 3 in `/test/simple_signal.test.ts` have decreased their average run time to:
  - `"test cached performance"`: from 200ms to 70ms
  - `"test uncached performance"`: from 650ms to 160ms

miscellaneous:
- bump minor version to `0.2.0`
- update dependencies:
  - `kitchensink_ts`: `v0.7.2` -> `v0.7.3`
- fix typos across repo