### PR TITLE
feature: dynamic signals 1

### DIFF
--- a/src/collection_signal.ts
+++ b/src/collection_signal.ts
@@ -7,12 +7,12 @@
 */
 
 import type { Context } from "./context.ts"
-import { object_assign, type ConstructorOf } from "./deps.ts"
+import { List, RcList, object_assign, type ConstructorOf } from "./deps.ts"
 import { MemoSignal_Factory, type MemoFn, type MemoSignalConfig, type SimpleSignalConfig } from "./signal.ts"
-import type { Accessor, ID, Identifiable, PureAccessor } from "./typedefs.ts"
+import type { Accessor, ID, Identifiable, PureAccessor, UNTRACKED_ID } from "./typedefs.ts"
 
 /** this information is needed by the proxy-like data-structures that run signals when they are mutated. <br>
- * see {@link Uniset} and {@link List} for an example.
+ * see {@link UnisetCollection} and {@link ListCollection} for an example.
 */
 interface BoundSignalInfo {
 	id: ID
@@ -20,7 +20,7 @@ interface BoundSignalInfo {
 }
 
 /** a unique set of {@link Accessor | Accessors}, that implements all builtin `Set` class methods, and fires a signal update upon mutation. */
-export class Uniset<A extends Accessor<any>> extends Set<A> implements Identifiable<{}> {
+export class UnisetCollection<A extends Accessor<any>> extends Set<A> implements Identifiable<{}> {
 	declare public readonly id: number
 	declare protected readonly ctx: Context
 
@@ -84,6 +84,71 @@ export class Uniset<A extends Accessor<any>> extends Set<A> implements Identifia
 	}
 }
 
+// @ts-ignore: I don't know why typescript is complaining about the signatures of the static `from` and `of` methods being incompatible with the super class.
+export class ListCollection<A extends Accessor<any>> extends RcList<A> implements Identifiable<{}> {
+	declare public readonly id: number
+	declare protected readonly ctx: Context
+	private disabled: boolean = true
+
+	constructor(config: BoundSignalInfo, items: Iterable<A> = []) {
+		super()
+		object_assign(this, config)
+		// the `super.push` method will consequently call `this.incRc`, and then `this.onAdded`.
+		// but that will result in the firing of an update cycle due to `runID` in `this.onAdded`,
+		// which is not what we want initially to happen (since it will defy the `defer` config option).
+		// thus we introduce the `this.disabled` member to take of not allowing `runId` to get executed in the first run.
+		// but the dependency of this list on the `item: A` will still get added to the dependency graph via `addEdge` in `this.onAdded`.
+		this.push(...items)
+		this.disabled = false
+	}
+
+	protected onAdded(item: A): void {
+		this.ctx.addEdge(item.id, this.id)
+	}
+
+	protected onDeleted(item: A): void {
+		this.ctx.delEdge(item.id, this.id)
+	}
+
+	protected incRcs(...items: A[]): void {
+		super.incRcs(...items)
+		// important detail: in the constructor, when `super()` is called, it consequently calls `this.incRcs`, which is this method.
+		// this happens before we assign `ctx`, `id`, etc... to `this` (via the `object_assign(this, config)` line in the constructor).
+		// as a result, on the very first call to `this.incRcs`, `this.ctx` and `this.id` are undefined.
+		// which is why we put the optional chaining operator in it (i.e. `this.ctx?.runId` and `this.disabled ?? true`).
+		if (!(this.disabled ?? true) && items.length > 0) { this.ctx?.runId(this.id) }
+	}
+
+	protected decRcs(...items: A[]): void {
+		super.decRcs(...items)
+		if (!(this.disabled ?? true) && items.length > 0) { this.ctx?.runId(this.id) }
+	}
+
+	splice(start: number, deleteCount?: number | undefined, ...items: A[]): A[] {
+		let return_value: A[]
+		this.ctx.batch.scopedBatching(() => { return_value = super.splice(start, deleteCount, ...items) })
+		return return_value!
+	}
+
+	swap(index1: number, index2: number): void {
+		if (index1 === index2) { return }
+		const { id, ctx: { batch, runId } } = this
+		batch.scopedBatching(() => {
+			super.swap(index1, index2)
+			runId(id)
+		})
+	}
+
+	set(index: number, value: A): A {
+		let return_value: A
+		this.ctx.batch.scopedBatching(() => { return_value = super.set(index, value) })
+		return return_value!
+	}
+
+	declare static from: <T, A extends Accessor<any>>(arrayLike: ArrayLike<T>, mapfn?: (v: T, k: number) => A, thisArg?: any) => ListCollection<A>
+	declare static of: <A extends Accessor<any>>(...items: A[]) => ListCollection<A>
+}
+
 // TODO: consider whether or not `CollectionSignalConfig` should contain an `fn: MemoFn<V>` member which should describe how to convert `dataClass<Accessor<T>>` to `valueClass<T>`
 //       and then remove the need for the `fn` function in `CollectionSignal` when calling its `super` constructor.
 
@@ -115,8 +180,8 @@ export const CollectionSignal_Factory = <D, V>(data_structure_class_config: Coll
 	const { dataClass, valueClass } = data_structure_class_config
 
 	return class CollectionSignal extends ctx.getClass(MemoSignal_Factory)<V> {
-		declare data: D
-		declare value: V
+		declare readonly data: D
+		declare readonly value: V
 
 		constructor(
 			fn: MemoFn<V>,
@@ -152,18 +217,18 @@ export const CollectionSignal_Factory = <D, V>(data_structure_class_config: Coll
 
 /** creates a signal that internally maintains a `Set` collection of {@link Accessor | `Accessors\<T\>`}, but returns a `Set<T>` when accessed (via the getter function). <br>
  * this signal will fire an update whenever one of its constituent signal items fires an update. <br>
- * this signal also fires independently when either _new_ {@link Accessor} item(s) are added (via the {@link UnisetSignal.items.addItems}), or when _old_ item(s) are removed (via the {@link UnisetSignal.items.delItems}).
+ * this signal also fires independently when either _new_ {@link Accessor} item(s) are added (via the {@link UnisetSignal.data.addItems}), or when _old_ item(s) are removed (via the {@link UnisetSignal.data.delItems}).
 */
 export const UnisetSignal_Factory = (ctx: Context) => {
 	const
-		dataClass = Uniset,
+		dataClass = UnisetCollection,
 		valueClass = Set,
 		signalSuperClass = CollectionSignal_Factory.bind(undefined, { dataClass, valueClass })
 
 	/** {@inheritDoc UnisetSignal_Factory} */
 	return class UnisetSignal<T> extends ctx.getClass(signalSuperClass) {
-		declare data: Uniset<Accessor<T>>
-		declare value: Set<T>
+		declare readonly data: UnisetCollection<Accessor<T>>
+		declare readonly value: Set<T>
 
 		constructor(
 			items: Iterable<Accessor<T>> = [],
@@ -172,7 +237,7 @@ export const UnisetSignal_Factory = (ctx: Context) => {
 			super((rid: number) => {
 				const { data, value } = this
 				value.clear()
-				data.forEach((item) => { value.add(item(0)) })
+				data.forEach((item) => { value.add(item(0 as UNTRACKED_ID)) })
 				return value
 			}, { ...config, value: items })
 		}
@@ -183,7 +248,7 @@ export const UnisetSignal_Factory = (ctx: Context) => {
 		): [
 				idUniset: number,
 				getUniset: Accessor<Set<T>>,
-				data: Uniset<Accessor<T>>,
+				data: UnisetCollection<Accessor<T>>,
 			] {
 			const new_signal = new this<T>(items, config)
 			return [
@@ -194,3 +259,55 @@ export const UnisetSignal_Factory = (ctx: Context) => {
 		}
 	}
 }
+
+/** creates a signal that internally maintains a `List` collection of {@link Accessor | `Accessors\<T\>`}, but returns a `List<T>` (which is a subclass of `Array<T>`) when accessed (via the getter function). <br>
+ * this signal will fire an update whenever one of its constituent signal items fires an update. <br>
+ * this signal also fires independently when either _new_ {@link Accessor} item(s) are added (via array methods, such as {@link UnisetSignal.data.push}), or when _old_ item(s) are removed (via array methods, such as {@link UnisetSignal.data.pop}).
+*/
+export const ListSignal_Factory = (ctx: Context) => {
+	const
+		dataClass = ListCollection,
+		valueClass = List,
+		signalSuperClass = CollectionSignal_Factory.bind(undefined, { dataClass, valueClass })
+
+	/** {@inheritDoc ListSignal_Factory} */
+	return class ListSignal<T> extends ctx.getClass(signalSuperClass) {
+		declare readonly data: ListCollection<Accessor<T>>
+		declare readonly value: List<T>
+
+		constructor(
+			items: Iterable<Accessor<T>> = [],
+			config?: Omit<SimpleSignalConfig<T>, "equals" | "value">,
+		) {
+			super((rid: number) => {
+				const { data, value } = this
+				value.splice(0) // clear all of the array's elements
+				// TODO: consider whether or not we should use `item?.(0)` instead of `item(0)`, as it might be possible for some `item`s to be `undefined`.
+				//       it comes down to user preference:
+				//       - do they prefer simplicity of having empty elements getting mapped to `undefined`,
+				//       - or would they like to get warned via fatal error, that their list is not entirely made out of Accessors.
+				value.push(...data.mapToArray((item) => item(0 as UNTRACKED_ID)))
+				return value
+			}, { ...config, value: items })
+		}
+
+		static create<T>(
+			items: Iterable<Accessor<T>> = [],
+			config?: Omit<SimpleSignalConfig<T>, "equals" | "value">,
+		): [
+				idList: number,
+				getList: Accessor<List<T>>,
+				data: ListCollection<Accessor<T>>,
+			] {
+			const new_signal = new this<T>(items, config)
+			return [
+				new_signal.id,
+				new_signal.bindMethod("get") as any,
+				new_signal.data
+			]
+		}
+	}
+}
+
+// TODO: implement a `MapCollection<K, V extends Accessor<any>>` and its complementary `MapSignal<K, V extends Accessor<any>>`.
+// TODO: implement a `ObjectCollection<SCHEMA>` and its complementary `ObjectSignal<SCHEMA>`, where `SCHEMA` is an interface with any `key: K extends PropertyKey`, and `value: V extends Accessor<any>` pairs.

--- a/src/collection_signal.ts
+++ b/src/collection_signal.ts
@@ -7,19 +7,97 @@
 */
 
 import type { Context } from "./context.ts"
+import { object_assign } from "./deps.ts"
 import { MemoSignal_Factory, type SimpleSignalConfig } from "./signal.ts"
-import type { Accessor, Identifiable, PureAccessor } from "./typedefs.ts"
+import type { Accessor, ID, Identifiable, PureAccessor } from "./typedefs.ts"
 
+/** this information is needed by the proxy-like data-structures that run signals when they are mutated. <br>
+ * see {@link Uniset} for an example.
+*/
+interface BoundSignalInfo {
+	id: ID
+	addEdge: Context["addEdge"]
+	delEdge: Context["delEdge"]
+	runId: Context["runId"]
+}
+
+/** a unique set of {@link Accessor | Accessors}, that implements all builtin `Set` class methods, and fires a signal update upon mutation. */
+class Uniset<A extends Accessor<any>> extends Set<A> implements Identifiable<{}> {
+	declare public readonly id: number
+	declare protected readonly addEdge: (src_id: number, dst_id: number) => boolean
+	declare protected readonly delEdge: (src_id: number, dst_id: number) => boolean
+	declare protected readonly runId: (id: number) => boolean
+
+	constructor(config: BoundSignalInfo, items: Iterable<A> = []) {
+		// we do not pass `items` to the super constructor, because it internally uses `this.add` to add the items,
+		// and as we know, since that method is overloaded here, and requires the `config` to be assigned to `this` before being used,
+		// and we can't assign `config` to `this` before calling the super constructor,
+		// so the only way out is by not adding the initial items via the super constructor, and instead adding them manually, one by one later on.
+		super()
+		object_assign(this, config)
+		const { addEdge, id } = config
+		// the initial items are added as a dependency, but they will NOT trigger an update cycle via `runId`.
+		// this is because we want the user of this class to decide whether or not it should fire initially.
+		// the default behavior is similar to `defer`ing
+		for (const item of items) {
+			super.add(item)
+			addEdge(item.id, id)
+		}
+	}
+
+	addItems(...items: A[]): void {
+		const { id, addEdge, runId } = this
+		let mutated = false
+		items.forEach((item) => {
+			if (!super.has(item)) {
+				super.add(item)
+				addEdge(item.id, id)
+				mutated = true
+			}
+		})
+		if (mutated) { runId(id) }
+	}
+
+	delItems(...items: A[]): void {
+		const { id, delEdge, runId } = this
+		let mutated = false
+		items.forEach((item) => {
+			if (super.delete(item)) {
+				delEdge(item.id, id)
+				mutated = true
+			}
+		})
+		if (mutated) { runId(id) }
+	}
+
+	add(value: A): this {
+		this.addItems(value)
+		return this
+	}
+
+	delete(value: A): boolean {
+		const item_exists = super.has(value)
+		this.delItems(value)
+		return item_exists
+	}
+
+	clear(): void {
+		// the following is not an efficient implementation.
+		// it could have been faster if I had exposed `fmap` and `rmap` from the `Context`, but I don't want to do that.
+		this.delItems(...this)
+	}
+}
 
 /** creates a signal that internally maintains a `Set` collection of {@link Accessor | `Accessors\<T\>`}, but returns a `Set<T>` when accessed (via the getter function). <br>
  * this signal will fire an update whenever one of its constituent signal items fires an update. <br>
- * this signal also fires independently when either _new_ {@link Accessor} item(s) are added (via the {@link UnisetStateSignal.addItems}), or when _old_ item(s) are removed (via the {@link UnisetStateSignal.delItems}).
+ * this signal also fires independently when either _new_ {@link Accessor} item(s) are added (via the {@link UnisetSignal.items.addItems}), or when _old_ item(s) are removed (via the {@link UnisetSignal.items.delItems}).
 */
-export const UnisetStateSignal_Factory = (ctx: Context) => {
+export const UnisetSignal_Factory = (ctx: Context) => {
 	const { runId, addEdge, delEdge } = ctx
-	//@ts-ignore: the function signature of the static `create` method is different from its base class. but we don't care.
-	return class UnisetStateSignal<T> extends ctx.getClass(MemoSignal_Factory)<Set<T>> {
-		declare items: Set<Accessor<T>>
+	/** {@inheritDoc UnisetSignal_Factory} */
+	// @ts-ignore: the function signature of the static `create` method is different from its base class. but we don't care.
+	return class UnisetSignal<T> extends ctx.getClass(MemoSignal_Factory)<Set<T>> {
+		declare items: Uniset<Accessor<T>>
 		declare value: Set<T>
 
 		constructor(
@@ -32,35 +110,9 @@ export const UnisetStateSignal_Factory = (ctx: Context) => {
 				items.forEach((item) => { value.add(item(0)) })
 				return value
 			}, { ...config, value: new Set(), defer: true, equals: false })
-			this.items = new Set(items)
 			const id = this.id
-			for (const item of items) { addEdge(item.id, id) }
+			this.items = new Uniset({ id, addEdge, delEdge, runId }, items)
 			if (config?.defer === false) { super.run() }
-		}
-
-		addItems(...items: Array<Accessor<T>>): void {
-			const { items: current_items, id } = this
-			let mutated = false
-			items.forEach((item) => {
-				if (!current_items.has(item)) {
-					current_items.add(item)
-					addEdge(item.id, id)
-					mutated = true
-				}
-			})
-			if (mutated) { runId(id) }
-		}
-
-		delItems(...items: Array<Accessor<T>>): void {
-			const { items: current_items, id } = this
-			let mutated = false
-			items.forEach((item) => {
-				if (current_items.delete(item)) {
-					delEdge(item.id, id)
-					mutated = true
-				}
-			})
-			if (mutated) { runId(id) }
 		}
 
 		static create<T>(
@@ -69,16 +121,16 @@ export const UnisetStateSignal_Factory = (ctx: Context) => {
 		): [
 				idUniset: number,
 				getUniset: Accessor<Set<T>>,
-				addItems: Identifiable<(...items: Array<Accessor<T>>) => void>,
-				delItems: Identifiable<(...items: Array<Accessor<T>>) => void>,
+				items: UnisetSignal<T>["items"],
 			] {
 			const new_signal = new this<T>(items, config)
 			return [
 				new_signal.id,
 				new_signal.bindMethod("get"),
-				new_signal.bindMethod("addItems"),
-				new_signal.bindMethod("delItems"),
+				new_signal.items
 			]
 		}
 	}
 }
+
+// DONE: consider whether or not to the "State" part in the names should be dropped.

--- a/src/collection_signal.ts
+++ b/src/collection_signal.ts
@@ -1,0 +1,84 @@
+/** this module contains signals that are composed of a collection of other sinal {@link Accessor}s. <br>
+ * all signals in here are capable of dynamically adding new dependency `Accessor`s, and removing previous ones. <br>
+ * but in order to work, the collection signal needs to know the `id` of the signal accessor it consumes (i.e. it must be {@link Identifiable}). <br>
+ * as such, the signal `Accessor`s provided to each collection __must__ be of {@link Accessor} function type, rather than of a {@link PureAccessor} type.
+ * 
+ * @module
+*/
+
+import type { Context } from "./context.ts"
+import { MemoSignal_Factory, type SimpleSignalConfig } from "./signal.ts"
+import type { Accessor, Identifiable, PureAccessor } from "./typedefs.ts"
+
+
+/** creates a signal that internally maintains a `Set` collection of {@link Accessor | `Accessors\<T\>`}, but returns a `Set<T>` when accessed (via the getter function). <br>
+ * this signal will fire an update whenever one of its constituent signal items fires an update. <br>
+ * this signal also fires independently when either _new_ {@link Accessor} item(s) are added (via the {@link UnisetStateSignal.addItems}), or when _old_ item(s) are removed (via the {@link UnisetStateSignal.delItems}).
+*/
+export const UnisetStateSignal_Factory = (ctx: Context) => {
+	const { runId, addEdge, delEdge } = ctx
+	//@ts-ignore: the function signature of the static `create` method is different from its base class. but we don't care.
+	return class UnisetStateSignal<T> extends ctx.getClass(MemoSignal_Factory)<Set<T>> {
+		declare items: Set<Accessor<T>>
+		declare value: Set<T>
+
+		constructor(
+			items: Iterable<Accessor<T>> = [],
+			config?: Omit<SimpleSignalConfig<T>, "equals">,
+		) {
+			super((rid: number) => {
+				const { items, value } = this
+				value.clear()
+				items.forEach((item) => { value.add(item(0)) })
+				return value
+			}, { ...config, value: new Set(), defer: true, equals: false })
+			this.items = new Set(items)
+			const id = this.id
+			for (const item of items) { addEdge(item.id, id) }
+			if (config?.defer === false) { super.run() }
+		}
+
+		addItems(...items: Array<Accessor<T>>): void {
+			const { items: current_items, id } = this
+			let mutated = false
+			items.forEach((item) => {
+				if (!current_items.has(item)) {
+					current_items.add(item)
+					addEdge(item.id, id)
+					mutated = true
+				}
+			})
+			if (mutated) { runId(id) }
+		}
+
+		delItems(...items: Array<Accessor<T>>): void {
+			const { items: current_items, id } = this
+			let mutated = false
+			items.forEach((item) => {
+				if (current_items.delete(item)) {
+					delEdge(item.id, id)
+					mutated = true
+				}
+			})
+			if (mutated) { runId(id) }
+		}
+
+		static create<T>(
+			items: Iterable<Accessor<T>> = [],
+			config?: Omit<SimpleSignalConfig<T>, "equals">
+		): [
+				idUniset: number,
+				getUniset: Accessor<Set<T>>,
+				addItems: Identifiable<(...items: Array<Accessor<T>>) => void>,
+				delItems: Identifiable<(...items: Array<Accessor<T>>) => void>,
+			] {
+			const new_signal = new this<T>(items, config)
+			return [
+				new_signal.id,
+				new_signal.bindMethod("get"),
+				new_signal.bindMethod("addItems"),
+				new_signal.bindMethod("delItems"),
+			]
+		}
+	}
+}

--- a/src/collection_signal.ts
+++ b/src/collection_signal.ts
@@ -7,26 +7,22 @@
 */
 
 import type { Context } from "./context.ts"
-import { object_assign } from "./deps.ts"
-import { MemoSignal_Factory, type SimpleSignalConfig } from "./signal.ts"
+import { object_assign, type ConstructorOf } from "./deps.ts"
+import { MemoSignal_Factory, type MemoFn, type MemoSignalConfig, type SimpleSignalConfig } from "./signal.ts"
 import type { Accessor, ID, Identifiable, PureAccessor } from "./typedefs.ts"
 
 /** this information is needed by the proxy-like data-structures that run signals when they are mutated. <br>
- * see {@link Uniset} for an example.
+ * see {@link Uniset} and {@link List} for an example.
 */
 interface BoundSignalInfo {
 	id: ID
-	addEdge: Context["addEdge"]
-	delEdge: Context["delEdge"]
-	runId: Context["runId"]
+	ctx: Context
 }
 
 /** a unique set of {@link Accessor | Accessors}, that implements all builtin `Set` class methods, and fires a signal update upon mutation. */
-class Uniset<A extends Accessor<any>> extends Set<A> implements Identifiable<{}> {
+export class Uniset<A extends Accessor<any>> extends Set<A> implements Identifiable<{}> {
 	declare public readonly id: number
-	declare protected readonly addEdge: (src_id: number, dst_id: number) => boolean
-	declare protected readonly delEdge: (src_id: number, dst_id: number) => boolean
-	declare protected readonly runId: (id: number) => boolean
+	declare protected readonly ctx: Context
 
 	constructor(config: BoundSignalInfo, items: Iterable<A> = []) {
 		// we do not pass `items` to the super constructor, because it internally uses `this.add` to add the items,
@@ -35,7 +31,7 @@ class Uniset<A extends Accessor<any>> extends Set<A> implements Identifiable<{}>
 		// so the only way out is by not adding the initial items via the super constructor, and instead adding them manually, one by one later on.
 		super()
 		object_assign(this, config)
-		const { addEdge, id } = config
+		const { id, ctx: { addEdge } } = config
 		// the initial items are added as a dependency, but they will NOT trigger an update cycle via `runId`.
 		// this is because we want the user of this class to decide whether or not it should fire initially.
 		// the default behavior is similar to `defer`ing
@@ -46,7 +42,7 @@ class Uniset<A extends Accessor<any>> extends Set<A> implements Identifiable<{}>
 	}
 
 	addItems(...items: A[]): void {
-		const { id, addEdge, runId } = this
+		const { id, ctx: { addEdge, runId } } = this
 		let mutated = false
 		items.forEach((item) => {
 			if (!super.has(item)) {
@@ -59,7 +55,7 @@ class Uniset<A extends Accessor<any>> extends Set<A> implements Identifiable<{}>
 	}
 
 	delItems(...items: A[]): void {
-		const { id, delEdge, runId } = this
+		const { id, ctx: { delEdge, runId } } = this
 		let mutated = false
 		items.forEach((item) => {
 			if (super.delete(item)) {
@@ -88,49 +84,113 @@ class Uniset<A extends Accessor<any>> extends Set<A> implements Identifiable<{}>
 	}
 }
 
-/** creates a signal that internally maintains a `Set` collection of {@link Accessor | `Accessors\<T\>`}, but returns a `Set<T>` when accessed (via the getter function). <br>
- * this signal will fire an update whenever one of its constituent signal items fires an update. <br>
- * this signal also fires independently when either _new_ {@link Accessor} item(s) are added (via the {@link UnisetSignal.items.addItems}), or when _old_ item(s) are removed (via the {@link UnisetSignal.items.delItems}).
+// TODO: consider whether or not `CollectionSignalConfig` should contain an `fn: MemoFn<V>` member which should describe how to convert `dataClass<Accessor<T>>` to `valueClass<T>`
+//       and then remove the need for the `fn` function in `CollectionSignal` when calling its `super` constructor.
+
+/** // TODO: I'm too sleepy */
+export interface CollectionSignalConfig<D, V> {
+	dataClass: ConstructorOf<D, [config: BoundSignalInfo, items?: Iterable<any>]>
+	valueClass: ConstructorOf<V>
+}
+
+/** a generalized signal class factory, capable of holding a collection of {@link Accessor | Accessors} in its data structure {@link D},
+ * which then transforms into a collection of values held inside of data structure {@link V}, when this signal's accessor (value getter) is called. <br>
+ * this factory can adapt to many common collection data structure, such as `Set`, `Array`, `Map`, and other custom collections.
+ * but you will need to write an appropriate {@link data_structure_class_config["dataClass"]} class for it, which would fire an update when mutations occur its collection of {@link Accessor | Accessors}.
+ * 
+ * for instance, if you ultimately wish to create signals that are "set-like collection of accessors", then you'd want:
+ * - `D = dataClass = Set // of type Set<Accessor<T>>`
+ * - `V = valueClass = Set // of type Set<T>`
+ * 
+ * @param data_structure_class_config this object should contain the class of the collection datatype when the `Accessor` is called,
+ *   and also the class of the collection datatype which stores a collection of `Accessor` functions to retrieve from.
+ *   see {@link CollectionSignalConfig} for more information and examples.
+ * @param ctx the signal context on which this data structure will function in.
+ *   it is needed by the data structure in order to fire update cycles natively.
+ * @returns the signal constructing class that is adapted to your provided collection data structures.
+ *   in order to use it, you will need to extend it, and call the `super` constructor with the appropriate `fn` memo function
+ *   that converts `dataClass<Accessor<T>>` to `valueClass<T>`
 */
-export const UnisetSignal_Factory = (ctx: Context) => {
-	const { runId, addEdge, delEdge } = ctx
-	/** {@inheritDoc UnisetSignal_Factory} */
-	// @ts-ignore: the function signature of the static `create` method is different from its base class. but we don't care.
-	return class UnisetSignal<T> extends ctx.getClass(MemoSignal_Factory)<Set<T>> {
-		declare items: Uniset<Accessor<T>>
-		declare value: Set<T>
+export const CollectionSignal_Factory = <D, V>(data_structure_class_config: CollectionSignalConfig<D, V>, ctx: Context) => {
+	const { dataClass, valueClass } = data_structure_class_config
+
+	return class CollectionSignal extends ctx.getClass(MemoSignal_Factory)<V> {
+		declare data: D
+		declare value: V
 
 		constructor(
-			items: Iterable<Accessor<T>> = [],
-			config?: Omit<SimpleSignalConfig<T>, "equals">,
+			fn: MemoFn<V>,
+			config?: Omit<MemoSignalConfig<Iterable<any>>, "equals">,
 		) {
-			super((rid: number) => {
-				const { items, value } = this
-				value.clear()
-				items.forEach((item) => { value.add(item(0)) })
-				return value
-			}, { ...config, value: new Set(), defer: true, equals: false })
+			super(fn, { ...config, value: new valueClass(), defer: true, equals: false })
 			const id = this.id
-			this.items = new Uniset({ id, addEdge, delEdge, runId }, items)
+			this.data = new dataClass({ id, ctx }, config?.value)
 			if (config?.defer === false) { super.run() }
 		}
 
-		static create<T>(
-			items: Iterable<Accessor<T>> = [],
-			config?: Omit<SimpleSignalConfig<T>, "equals">
+		// the signature of the actual `static create` method is incomplatible with the super method, due to the generics used.
+		// in addition we need to relax the typing of this static method, since its derived subclasses will be using a different signature.
+		// as such, we introduce the alternate generic signature `static create(...args: any[]): any` to allow for for this flexibility.
+		static create(...args: any[]): any
+		static create(
+			fn: MemoFn<V>,
+			config?: Omit<MemoSignalConfig<Iterable<any>>, "equals">,
 		): [
-				idUniset: number,
-				getUniset: Accessor<Set<T>>,
-				items: UnisetSignal<T>["items"],
+				id: number,
+				getValue: Accessor<V>,
+				data: D,
 			] {
-			const new_signal = new this<T>(items, config)
+			const new_signal = new this(fn, config)
 			return [
 				new_signal.id,
 				new_signal.bindMethod("get"),
-				new_signal.items
+				new_signal.data
 			]
 		}
 	}
 }
 
-// DONE: consider whether or not to the "State" part in the names should be dropped.
+/** creates a signal that internally maintains a `Set` collection of {@link Accessor | `Accessors\<T\>`}, but returns a `Set<T>` when accessed (via the getter function). <br>
+ * this signal will fire an update whenever one of its constituent signal items fires an update. <br>
+ * this signal also fires independently when either _new_ {@link Accessor} item(s) are added (via the {@link UnisetSignal.items.addItems}), or when _old_ item(s) are removed (via the {@link UnisetSignal.items.delItems}).
+*/
+export const UnisetSignal_Factory = (ctx: Context) => {
+	const
+		dataClass = Uniset,
+		valueClass = Set,
+		signalSuperClass = CollectionSignal_Factory.bind(undefined, { dataClass, valueClass })
+
+	/** {@inheritDoc UnisetSignal_Factory} */
+	return class UnisetSignal<T> extends ctx.getClass(signalSuperClass) {
+		declare data: Uniset<Accessor<T>>
+		declare value: Set<T>
+
+		constructor(
+			items: Iterable<Accessor<T>> = [],
+			config?: Omit<SimpleSignalConfig<T>, "equals" | "value">,
+		) {
+			super((rid: number) => {
+				const { data, value } = this
+				value.clear()
+				data.forEach((item) => { value.add(item(0)) })
+				return value
+			}, { ...config, value: items })
+		}
+
+		static create<T>(
+			items: Iterable<Accessor<T>> = [],
+			config?: Omit<SimpleSignalConfig<T>, "equals" | "value">,
+		): [
+				idUniset: number,
+				getUniset: Accessor<Set<T>>,
+				data: Uniset<Accessor<T>>,
+			] {
+			const new_signal = new this<T>(items, config)
+			return [
+				new_signal.id,
+				new_signal.bindMethod("get") as any,
+				new_signal.data
+			]
+		}
+	}
+}

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -26,3 +26,241 @@ export type Stringifyable = { toString(): string }
 
 // TODO: add multiple logging options: such as one for `Signal.get` logging, and one for `Context.updateFireCycle`, etc...
 // TODO: add a link to license in `readme.md`
+
+// TODO: import the following from the newer version of `kitchensink`
+import { bind_map_delete, bind_map_get, bind_map_set } from "jsr:@oazmi/kitchensink@0.7.5/binder"
+import { array_from } from "jsr:@oazmi/kitchensink@0.7.5/builtin_aliases_deps"
+import { modulo } from "jsr:@oazmi/kitchensink@0.7.5/numericmethods"
+
+
+/** a very simple python-like `List`s class, that allows for in-between insertions, deletions, and replacements, to keep the list compact. */
+export class List<T> extends Array<T> {
+	/** inserts an item at the specified index, shifting all items ahead of it one position to the front. <br>
+	 * negative indices are also supported for indicating the position of the newly added item _after_ the array's length has incremented.
+	 * 
+	 * @example
+	 * ```ts
+	 * const arr = new List(0, 1, 2, 3, 4)
+	 * arr.insert(-1, 5) // === [0, 1, 2, 3, 4, 5] // similar to pushing
+	 * arr.insert(-2, 4.5) // === [0, 1, 2, 3, 4, 4.5, 5]
+	 * arr.insert(1, 0.5) // === [0, 0.5, 1, 2, 3, 4, 4.5, 5]
+	 * ```
+	*/
+	insert(index: number, item: T): void {
+		const i = modulo(index, this.length)
+		this.splice(i, 0, item)
+	}
+
+	/** deletes an item at the specified index, shifting all items ahead of it one position to the back. <br>
+	 * negative indices are also supported for indicating the deletion index from the end of the array.
+	 * 
+	 * @example
+	 * ```ts
+	 * const arr = new List(0, 0.5, 1, 2, 3, 4, 4.5, 5)
+	 * arr.delete(-1) // === [0, 0.5, 1, 2, 3, 4, 4.5] // similar to popping
+	 * arr.delete(-2) // === [0, 0.5, 1, 2, 3, 4.5]
+	 * arr.delete(1) // === [0, 1, 2, 3, 4.5]
+	 * ```
+	*/
+	delete(index: number): T | undefined {
+		return this.splice(index, 1)[0]
+	}
+
+	/** get an item at the specified `index`. <br>
+	 * this is equivalent to using index-based getter: `my_list[index]`.
+	*/
+	get(index: number): T | undefined { return this[index] }
+
+	/** sets the value at the specified index. <br>
+	 * prefer using this method instead of index-based assignment, because subclasses may additionally cary out more operations with this method.
+	 * and for attaining compatibility between `List` and its subclasses, it would be in your best interest to use the `set` method.
+	 * - **not recommended**: `my_list[index] = "hello"`
+	 * - **preferred**: `my_list.set(index, "hello")`
+	*/
+	set(index: number, value: T): T { return (this[index] = value) }
+
+	static from<T, U = T>(arrayLike: ArrayLike<T>, mapfn?: (v: T, k: number) => U, thisArg?: any): List<U> {
+		const new_list = new this<U>()
+		new_list.push(...array_from(arrayLike, mapfn!, thisArg))
+		return new_list
+	}
+
+	static of<T>(...items: T[]): List<T> {
+		return this.from<T>(items)
+	}
+}
+
+/** a specialized list that keeps track of the number of duplicates of each item in the list, similar to a reference counter.
+ * 
+ * this class automatically updates the reference counter on any mutations to the list at `O(log(n))`, where `n` is the number of unique items. <br>
+ * note that you __must__ use the {@link set} method for index-based assignment, otherwise the class will not be able track the changes made.
+ * - **don't do**: `my_list[index] = "hello"`
+ * - **do**: `my_list.set(index, "hello")`
+ * 
+ * @example
+ * ```ts
+ * class TrackedList<T> extends RcList<T> {
+ * 	public onAdded(item: T): void {
+ * 		console.log(`new item introduced: ${item}`)
+ * 	}
+ * 
+ * 	public onDeleted(item: T): void {
+ * 		console.log(`item completely removed: ${item}`)
+ * 	}
+ * }
+ * 
+ * const list = new TrackedList<number>()
+ * list.push(1, 2, 2, 3)
+ * // logs: "new item introduced: 1", "new item introduced: 2", "new item introduced: 3"
+ * 
+ * list.pop() // removes 3
+ * // logs: "item completely removed: 3"
+ * 
+ * list.splice(0, 1) // removes 1
+ * // logs: "item completely removed: 1"
+ * 
+ * list.unshift(4, 4, 5)
+ * // logs: "new item introduced: 4", "new item introduced: 5"
+ * 
+ * list.shift() // removes 4
+ * // logs: "item completely removed: 4"
+ * 
+ * list.set(0, 6) // replaces 2 with 6
+ * // logs: "item completely removed: 2", "new item introduced: 6"
+ * 
+ * list.set(99, 9999) // `list[99] = 9999`, in addition to extending the length of the list to `100`
+ * // logs: "new item introduced: 99"
+ * // the reference counter of `undefined` is now `95`, because the length of the list was extended by `96` elements,
+ * // and the final element (index `99`) was assigned the value of `9999`.
+ * // note that `onAdded` is not called for `undefined` elements that are introduced as a consequence of the list extending after assignment.
+ * // but `onAdded` will be called when the user _actually_ inserts an `undefined` element via direct mutation methods.
+ * ```
+*/
+export class RcList<T> extends List<T> {
+	/** the reference counting `Map`, that bookkeeps the multiplicity of each item in the list. */
+	protected readonly rc: Map<T, number> = new Map()
+
+	/** get the reference count (multiplicity) of a specific item in the list. */
+	readonly getRc = bind_map_get(this.rc)
+
+	/** set the reference count of a specific item in the list. */
+	protected readonly setRc = bind_map_set(this.rc)
+
+	/** delete the reference counting of a specific item in the list. a `true` is returned if the item did exist in {@link rc}, prior to deletion. */
+	protected readonly delRc = bind_map_delete(this.rc)
+
+	constructor(...args: ConstructorParameters<typeof List<T>>) {
+		super(...args)
+		this.incRcs(...this)
+	}
+
+	/** this overridable method gets called when a new unique item is determined to be added to the list. <br>
+	 * this method is called _before_ the item is actually added to the array, but it is executed right _after_ its reference counter has incremented to `1`. <br>
+	 * avoid accessing or mutating the array itself in this method's body (consider it an undefined behavior).
+	 * 
+	 * @param item the item that is being added.
+	*/
+	protected onAdded(item: T): void { }
+
+	/** this overridable method gets called when a unique item (reference count of 1) is determined to be removed from the list. <br>
+	 * this method is called _before_ the item is actually removed from the array, but it is executed right _after_ its reference counter has been deleted. <br>
+	 * avoid accessing or mutating the array itself in this method's body (consider it an undefined behavior).
+	 * 
+	 * @param item the item that is being removed.
+	*/
+	protected onDeleted(item: T): void { }
+
+	/** increments the reference count of each item in the provided array of items.
+	 * 
+	 * @param items the items whose counts are to be incremented.
+	*/
+	protected incRcs(...items: T[]) {
+		const { getRc, setRc } = this
+		items.forEach((item) => {
+			const new_count = (getRc(item) ?? 0) + 1
+			setRc(item, new_count)
+			if (new_count === 1) { this.onAdded(item) }
+		})
+	}
+
+	/** decrements the reference count of each item in the provided array of items.
+	 * 
+	 * @param items the items whose counts are to be decremented.
+	*/
+	protected decRcs(...items: T[]) {
+		const { getRc, setRc, delRc } = this
+		items.forEach((item) => {
+			const new_count = (getRc(item) ?? 0) - 1
+			if (new_count > 0) {
+				setRc(item, new_count)
+			} else {
+				delRc(item)
+				this.onDeleted(item)
+			}
+		})
+	}
+
+	push(...items: T[]): number {
+		this.incRcs(...items)
+		return super.push(...items)
+	}
+
+	pop(): T | undefined {
+		const
+			previous_length = this.length,
+			item = super.pop()
+		if (this.length < previous_length) { this.decRcs(item as T) }
+		return item
+	}
+
+	shift(): T | undefined {
+		const
+			previous_length = this.length,
+			item = super.shift()
+		if (this.length < previous_length) { this.decRcs(item as T) }
+		return item
+	}
+
+	unshift(...items: T[]): number {
+		this.incRcs(...items)
+		return super.unshift(...items)
+	}
+
+	splice(start: number, deleteCount?: number, ...items: T[]): T[] {
+		const removed_items = super.splice(start, deleteCount as number, ...items)
+		this.incRcs(...items)
+		this.decRcs(...removed_items)
+		return removed_items
+	}
+
+	/** sets the value at the specified index, updating the counter accordingly. <br>
+	 * always use this method instead of index-based assignment, because the latter is not interceptable (except when using proxies):
+	 * - **don't do**: `my_list[index] = "hello"`
+	 * - **do**: `my_list.set(index, "hello")`
+	*/
+	set(index: number, value: T): T {
+		const
+			old_value = super.get(index),
+			old_length = this.length,
+			increase_in_array_length = (index + 1) - old_length
+		if (increase_in_array_length === 1) {
+			// we handle this special case separately, because it would be more performant this way,
+			// and the `onDelete` method will not get called (due to `this.decRcs(old_value)`) for the just recently added `undefined` element (which is also immediately deleted)
+			this.push(value)
+		} else if ((value !== old_value) || (increase_in_array_length > 1)) {
+			value = super.set(index, value)
+			this.incRcs(value)
+			if (increase_in_array_length > 0) {
+				// if the array's length has extended due to the assignment,
+				// then we shall increment the count of `undefined` items, by the amount the array was extended by.
+				const { getRc, setRc } = this
+				setRc(undefined as T, (getRc(undefined as T) ?? 0) + increase_in_array_length)
+			}
+			this.decRcs(old_value as T)
+		}
+		return value
+	}
+
+	declare static from: <T, U = T>(arrayLike: ArrayLike<T>, mapfn?: (v: T, k: number) => U, thisArg?: any) => RcList<U>
+	declare static of: <T>(...items: T[]) => RcList<T>
+}

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -193,6 +193,14 @@ export const MemoSignal_Factory = (ctx: Context) => {
 		}
 
 		// TODO: consider whether or not MemoSignals should be able to be forced to fire independently
+		//       [20240611]: in order to allow derived classes to fire independently, it would be best if we _do_ allow the `forced` parameter to take action.
+		//                   so, as of now, it will take effect.
+		//                   However, I need to document this feature properly now, in addition to changing the signature to allow for a "fireMemo()" forcefull setter-like function.
+		//                   Moreover, I will need to consider the consequences on the existing derived classes, such as the `LazySignal`.
+		// UPDATE: nevermind, I will retract the comments above soon, and will not currently implement forced memo signals, as it will create ambiguity in the following regard:
+		//         when the signal is forced, it will certainly always ultimately propagate (via `SignalUpdateStatus.UPDATED`), but:
+		//         - will it update its current value (via `super.set(this.fn(this.rid))`)
+		//         - or will it skip rerunning the `fn` function and skip setting `this.value`
 		run(forced?: boolean): SignalUpdateStatus {
 			return super.set(this.fn(this.rid)) ?
 				SignalUpdateStatus.UPDATED :

--- a/test/collection_signal.list.test.ts
+++ b/test/collection_signal.list.test.ts
@@ -1,0 +1,80 @@
+
+import { ListSignal_Factory } from "../src/collection_signal.ts"
+import { Context } from "../src/context.ts"
+import { EffectSignal_Factory, MemoSignal_Factory, StateSignal_Factory } from "../src/signal.ts"
+import type { ID } from "../src/typedefs.ts"
+
+
+type Task = string
+
+const
+	ctx = new Context(),
+	createState = ctx.addClass(StateSignal_Factory),
+	createMemo = ctx.addClass(MemoSignal_Factory),
+	createEffect = ctx.addClass(EffectSignal_Factory),
+	createList = ctx.addClass(ListSignal_Factory)
+
+const
+	[idTask1, getTask1, setTask1] = createState<Task>("[ ] clean room"),
+	[idTask2, getTask2, setTask2] = createState<Task>("[ ] wash dishes"),
+	[idTask3, getTask3, setTask3] = createState<Task>("[ ] eat carrots"),
+	[idTask4, getTask4] = createMemo<Task>((id: ID) => {
+		const
+			task1 = getTask1(id),
+			task2 = getTask2(id),
+			both_done = (task1[1] === "x" && task2[1] === "x") ? "x" : " ",
+			both_tasks = task1.substring(4) + " AND " + task2.substring(4)
+		return `[${both_done}] ${both_tasks}`
+	}),
+	[idTask5, getTask5] = createMemo<Task>((id: ID) => {
+		const
+			you_are_full = getTask3(id)[1] === "x" ? "full" : undefined,
+			you_are_tired = getTask4(id)[1] === "x" ? "tired" : undefined,
+			your_status = (you_are_full || you_are_tired)
+				? "you are " + (you_are_full ?? you_are_tired) + (you_are_tired
+					? " AND " + you_are_tired
+					: ""
+				)
+				: undefined
+		return `[${your_status ? "x" : " "}] status: ${your_status ?? "blank"}`
+	})
+
+Deno.test("test1", () => {
+	const [idAllTasks, getAllTasks, allTasks] = createList([getTask1, getTask2, getTask3])
+	let number_of_all_tasks_updates = 0
+	createEffect((id) => {
+		const all_tasks = getAllTasks(id)
+		console.log("All tasks updated for the: ", number_of_all_tasks_updates++, "th time\n", all_tasks)
+	}, { defer: false })
+	// pushing pre-existing tasks will rerun the signal, since the array has mutated.
+	// but it will not bother adding the new entries as _new dependencies_, since it is aware that they had pre-existed (thanks to reference counting).
+	allTasks.push(getTask1, getTask2)
+	// the four operations below are also mutative
+	allTasks.set(3, getTask2)
+	allTasks.swap(2, 4)
+	allTasks.delete(2)
+	allTasks.splice(2, 1)
+	// swapping at the same index isn't mutative, so it doesn't fire an update signal
+	allTasks.swap(0, 0)
+	// you may also batch single actions together, so that only update cycle is fired, consisting of all the batched changes
+	ctx.batch.scopedBatching(() => {
+		allTasks.insert(0, getTask5)
+		allTasks.insert(-2, getTask4)
+	})
+	// updating an entry inside of the List will cause the list to also update.
+	ctx.batch.scopedBatching(() => {
+		setTask1("[x] clean room")
+		setTask3("[x] eat carrots")
+	})
+	// removing some dependencies (so that they are no longer connected to the subgraph containing the list),
+	// and then updating those removed dependencies will not update the list.
+	ctx.batch.scopedBatching(() => {
+		allTasks.delete(0) // this is `getTask5` (your status)
+		allTasks.delete(-1) // this is `getTask3` (eat carrot)
+		allTasks.delete(1) // this is `getTask2` (wash dishes)
+	})
+	// since `getTask3` vertex is no longer either a direct or indirect dependency of the List, so updating it will not cause the List to update
+	setTask3("[ ] eat carrots")
+	// however, since `getTask2` is indirectly a dependency of the List (via `getTask4`), so updating it will cause the List to update
+	setTask2("[x] wash dishes")
+})

--- a/test/collection_signal.test.ts
+++ b/test/collection_signal.test.ts
@@ -1,0 +1,80 @@
+
+import { UnisetStateSignal_Factory } from "../src/collection_signal.ts"
+import { Context } from "../src/context.ts"
+import { EffectSignal_Factory, MemoSignal_Factory, StateSignal_Factory } from "../src/signal.ts"
+
+interface BookMeta {
+	title: string
+	author: string
+	/** time published in milliseconds, since epoch. */
+	published: number
+	/** a dictionary of chapter numbers, and their corresponding chapter titles. */
+	chapters?: { [chapter_number: number]: string }
+}
+
+const
+	ctx = new Context(),
+	createState = ctx.addClass(StateSignal_Factory),
+	createMemo = ctx.addClass(MemoSignal_Factory),
+	createEffect = ctx.addClass(EffectSignal_Factory),
+	createUniset = ctx.addClass(UnisetStateSignal_Factory)
+
+const
+	[idBookA, getBookA, setBookA] = createState<BookMeta>({
+		title: "first book",
+		author: "first author",
+		published: 0,
+		chapters: { 0: "preface", 1: "oh no, it\'s explodia!, but no one\'s ever been able to summon him!", 99: "final chapter" }
+	}, { equals: false }),
+	[idBookB, getBookB, setBookB] = createState<BookMeta>({
+		title: "second book",
+		author: "second author",
+		published: 1000,
+	}, { equals: false }),
+	[idBookC, getBookC, setBookC] = createState<BookMeta>({
+		title: "third book",
+		author: "third author",
+		published: 2000,
+	}, { equals: false }),
+	[idBookD, getBookD] = createMemo<BookMeta>((id) => {
+		// BookD is derived from BookA and BookB
+		const
+			{ author, chapters } = getBookA(id),
+			{ title, published } = getBookB(id)
+		return { title, author: author + "\'s grandson", published, chapters }
+	}),
+	[idBookE, getBookE] = createMemo<BookMeta>((id) => {
+		// BookE is derived from BookA, BookC, and BookD
+		const
+			title = getBookA(id).title + ", edition D",
+			{ published } = getBookC(id),
+			{ author } = getBookD(id)
+		return { title, author, published }
+	})
+
+Deno.test("test1", () => {
+	const [idBooksUniset, getBooksUniset, addBooks, delBooks] = createUniset([getBookD, getBookA])
+	createEffect((id) => {
+		const all_books = getBooksUniset(id)
+		console.log(all_books)
+	}, { defer: false })
+	// adding pre-existing items should not rerun the signal.
+	addBooks(getBookA, getBookD)
+	// updating `setBookA` should ultimately update `BooksUniset`, and make the logging effect afterwards.
+	setBookA((prev) => {
+		prev!.author = "1st author"
+		return prev!
+	})
+	// removing pre-existing items should rerun the signal.
+	// TODO: investigate why deletion and addition of items does not cause the signal to rerun. could it have something to do with the `this.run` code? 
+	// scratch the above, it now works, because I should've used `ctx.runId` instead of `this.run`
+	delBooks(getBookA)
+	delBooks(getBookD)
+	// now, updating `setBookA` will not rerun/update `BooksUniset`, since it is no longer dependent (whether directly, or indirectly) in signals `getBookA` and `getBookD`.
+	setBookA((prev) => {
+		prev!.author = "nein-th author"
+		return prev!
+	})
+	console.log(getBooksUniset())
+})
+

--- a/test/collection_signal.test.ts
+++ b/test/collection_signal.test.ts
@@ -1,5 +1,5 @@
 
-import { UnisetStateSignal_Factory } from "../src/collection_signal.ts"
+import { UnisetSignal_Factory } from "../src/collection_signal.ts"
 import { Context } from "../src/context.ts"
 import { EffectSignal_Factory, MemoSignal_Factory, StateSignal_Factory } from "../src/signal.ts"
 
@@ -17,7 +17,7 @@ const
 	createState = ctx.addClass(StateSignal_Factory),
 	createMemo = ctx.addClass(MemoSignal_Factory),
 	createEffect = ctx.addClass(EffectSignal_Factory),
-	createUniset = ctx.addClass(UnisetStateSignal_Factory)
+	createUniset = ctx.addClass(UnisetSignal_Factory)
 
 const
 	[idBookA, getBookA, setBookA] = createState<BookMeta>({
@@ -53,13 +53,13 @@ const
 	})
 
 Deno.test("test1", () => {
-	const [idBooksUniset, getBooksUniset, addBooks, delBooks] = createUniset([getBookD, getBookA])
+	const [idBooksUniset, getBooksUniset, books] = createUniset([getBookD, getBookA])
 	createEffect((id) => {
 		const all_books = getBooksUniset(id)
 		console.log(all_books)
 	}, { defer: false })
 	// adding pre-existing items should not rerun the signal.
-	addBooks(getBookA, getBookD)
+	books.addItems(getBookA, getBookD)
 	// updating `setBookA` should ultimately update `BooksUniset`, and make the logging effect afterwards.
 	setBookA((prev) => {
 		prev!.author = "1st author"
@@ -68,8 +68,8 @@ Deno.test("test1", () => {
 	// removing pre-existing items should rerun the signal.
 	// TODO: investigate why deletion and addition of items does not cause the signal to rerun. could it have something to do with the `this.run` code? 
 	// scratch the above, it now works, because I should've used `ctx.runId` instead of `this.run`
-	delBooks(getBookA)
-	delBooks(getBookD)
+	books.delete(getBookA)
+	books.delete(getBookD)
 	// now, updating `setBookA` will not rerun/update `BooksUniset`, since it is no longer dependent (whether directly, or indirectly) in signals `getBookA` and `getBookD`.
 	setBookA((prev) => {
 		prev!.author = "nein-th author"

--- a/test/collection_signal.uniset.test.ts
+++ b/test/collection_signal.uniset.test.ts
@@ -46,7 +46,7 @@ const
 	[idBookE, getBookE] = createMemo<BookMeta>((id) => {
 		// BookE is derived from BookA, BookC, and BookD
 		const
-			title = getBookA(id).title + ", edition D",
+			title = getBookA(id).title + ", edition E",
 			{ published } = getBookC(id),
 			{ author } = getBookD(id)
 		return { title, author, published }
@@ -75,6 +75,12 @@ Deno.test("test1", () => {
 		prev!.author = "nein-th author"
 		return prev!
 	})
+	// adding `getBookE`, which has a dependency on `getBookA`. due to the mutation, the `getBooksUniset` will fire on its own.
+	books.add(getBookE)
+	// now, updating `setBookA` will update `BooksUniset`, since it updates `BookE`, which will then update `BooksUniset` (indirectly).
+	setBookA((prev) => {
+		prev!.author = "not an author"
+		return prev!
+	})
 	console.log(getBooksUniset())
 })
-


### PR DESCRIPTION
### description:

This PR introduces two dynamic signals that hold a _collection_ of `Accessor`s:
- `UnisetSignal`: holds a set of accessors (`Set<Accessor<T>>`), and when its value is requested, it returns the values of the accessors it is holding (as a `Set<T>`).
- `ListSignal`: holds an array of accessors (`RcList<Accessor<T>>`), and when its value is requested, it returns an array of the values of the accessors it is holding (as a `List<T>`).
  - The `List` data structure is just your plain old `Array` with the addition of a few useful methods (`insert`, `delete`, `swap`) that make it similar to python-style lists.
    In addition, it requires that you assign elemets using the `list.set(index, value)` method, instead of the index based assignment `list[index] = value`. This is so that its subclasses can keep track of what assignments are taking place (without having to resort to nasty proxies).
  - The `RcList` is a subclass of the `List` class, but it reference counts the elements that are added or removed from it.
    This feature is necessary for its signal compatible subclass `ListCollection` to be able to dynamically tell which `Accessor`s the signal is dependant on, and which of them are being dynamically removed completely (with no duplicates remaining) to de-allocate its dependency on them.

This PR builds on the `Identifiable` signal feature introduced in #8 , which simplifies the ability to tell the signal `id` of a signal jsut from its `Accessor`.


### justification:

Previously, basic dynamic collection based tasks were incredibly difficult to implement, and needed to be tailored to the specific datatype structure that was being held in a collection.
This is because the library formerly focused _additive_ signals, where, by design, _new_ signals that were created built themselves over static-and-existing older signals.
This made sense dependency-wise, because a `Memo` function would always carry the same set of dependencies.
But as a consequence, implementing basic collection-based dynamic signal, such as that of a "To-Do list" (i.e. an `Accessor<Array<Accessor<TodoInterface>>>`), was incredibly dificult.

With this PR, dynamic signals based on `Set`s or `Array`s become easy to implement using the library provided `UnisetSignal_Factory` and `ListSignal_Factory` exports.


### future:

In the future, I hope to add two more dynamic collections (in the `feature/dynamic-signals-2` branch):
- `MapCollection<K, V extends Accessor<any>>` and its complementary `MapSignal<K, V extends Accessor<any>>` for holding `Accessor`s in a  `Map` based datastructure.
- `ObjectCollection<SCHEMA>` and its complementary `ObjectSignal<SCHEMA>`, where `SCHEMA` is an interface with any `key: K extends PropertyKey`, and `value: V extends Accessor<any>` pairs.
